### PR TITLE
Check fileMapping.includeDirectories in filter

### DIFF
--- a/tasks/rpm.js
+++ b/tasks/rpm.js
@@ -54,7 +54,12 @@ function filterFiles(grunt, files) {
 						grunt.log.warn('The path %s is not a directory but it is marked as such', filepath, fileMapping.relativeTo);
 					}
 				}
-				if (fileMapping.relativeTo) {
+				else {
+					if (grunt.file.isDir(filepath) && !fileMapping.includeDirectories) {
+						return;
+					}
+				}
+                                if (fileMapping.relativeTo) {
 					if (grunt.file.doesPathContain(fileMapping.relativeTo, filepath)) {
 						fileConfig.path = path.relative(fileMapping.relativeTo, filepath);
 					} else {


### PR DESCRIPTION
By default, filterFiles includes directories in the %files list when captured by a glob pattern.  For files in system directories like /etc/init.d, the RPM will fail to install because it doesn't own the directory (e.g. "conflicts with file from package chkconfig").

This change disables it by default.  Specifying the includeDirectories: true in the file mapping will override this, and list directories in the spec file.
