### PR TITLE
Preserve file mode when copying to the build root

### DIFF
--- a/tasks/rpm.js
+++ b/tasks/rpm.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var path = require('path');
+var _fs = require('fs');
 var fs = require('fs.extra');
 var spec = require('./lib/default-spec-writer');
 
@@ -95,7 +96,10 @@ function copyFilesToPack(grunt, buildPath, filesToPack) {
 					// Copy a file to the destination directory inside the tmp folder.
 					grunt.verbose.writeln('Copying file "' + fileConfig.src + '" to "' + filepathDest + '"');
 					grunt.file.copy(fileConfig.src, filepathDest);
-					callback();
+					fs.lstat(fileConfig.src, function(err, stat) {
+						if (err) throw err;
+						_fs.chmod(filepathDest, stat.mode, callback);
+					});
 				}
 				
 			} catch(e) {


### PR DESCRIPTION
grunt.file.copy streams the bits around without carrying over the mode.  I modified the task to use the core fs module to read the mode from the source and set it on the destination.  Now you do not need to specify explicit attributes for single %files, nor do you need to run chmod in your %post script, since a glob pattern will capture everything you need.

This can likely be retired once https://github.com/gruntjs/grunt/pull/732 gets merged.
