### PR TITLE
Include symlinks when copying files to pack

### DIFF
--- a/tasks/rpm.js
+++ b/tasks/rpm.js
@@ -9,7 +9,6 @@
 
 var path = require('path');
 var _fs = require('fs');
-var mkdirp = require("mkdirp");
 var getDirName = require("path").dirname;
 var fs = require('fs.extra');
 var spec = require('./lib/default-spec-writer');


### PR DESCRIPTION
Identify symlinks and their destinations when filtering files, and create them when copying files to be packed.
