### PR TITLE
added fix into spec generation, see https://github.com/gastonelhordoy/gr...

### DIFF
--- a/tasks/lib/default-spec-writer.js
+++ b/tasks/lib/default-spec-writer.js
@@ -103,7 +103,7 @@ function readScriptlet(label, scriptFile) {
 }
 
 function skipBinariesInNoarchPackageError() {
-	return '%define _binaries_in_noarch_packages_terminate_build   0';
+	return '%define _binaries_in_noarch_packages_terminate_build   0\n\n';
 }
 
 /**


### PR DESCRIPTION
Fix for issue described here: https://github.com/gastonelhordoy/grunt-rpm/issues/11

Binaries in distribution package was throwing "Arch dependent binaries in noarch package" error by `rpmbuild`. Proposed solution fix that problem.
