### PR TITLE
updated the README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ grunt.initConfig({
 })
 ```
 
-In the last snippet 3 users and 1 group were configured for showing the different flavors of customization in terms of file ownership. The configuration was made with no particular deployment schema in mind.
+In the last snippet 3 users and 1 group were configured for showing the different flavors of customization in terms of file ownership. The configuration was made with no particular deployment schema in mind. **NOTE** The dest: must end in a '\' if the target is a directory AND the target doesn't exist. If the target doesn't exist and you intend a file, then the trailing '\' can be omitted.
 Most of the configuration is still picked from the `package.json` file except for the `license` field which is explicitly set to `'MIT'`.
 
 ## Contributing


### PR DESCRIPTION
I updated the README.md to make it clear that dest should end in a \ if you want it to be a directory and the destination directory does NOT exist. It took me a while to figure this out. I created a bug, but maybe this is a desired feature and it's best to simply let people know how it works.
