### PR TITLE
Added support for relative files path when packaging RPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Default value: (optional)
 
 The default dirmmode used for files that are being copied to the host as part of the installation process.
 
+#### options.relativeTo
+Type: `String`
+Default value: (optional)
+
+The base path for files to be packaged into the RPM within the target directory, what means `relativeTo: dist/` will transform `dist/index.html` to `index.html`.
+
 #### options.preInstall
 Type: `Object`
 Default value: (optional)
@@ -215,7 +221,7 @@ grunt.initConfig({
         {src: ['node_modules/**/*'], dest: '/opt/my/application', filter: function(filepath) {
             return !grunt.util._.startsWith(filepath, gruntPattern);
         }, username: 'myuser2', groupname: 'mygroup'},
-        {src: ['index.js', 'package.json'], dest: '/opt/my/application'}
+        {src: ['index.js', 'package.json'], dest: '/opt/my/application', relativeTo: 'dist/'}
     ],
     snapshot: {
         options: {

--- a/tasks/rpm.js
+++ b/tasks/rpm.js
@@ -96,7 +96,13 @@ function copyFilesToPack(grunt, buildPath, filesToPack) {
 			try {
 				var filepathDest;
 				if (detectDestType(grunt, fileConfig.dest) === 'directory') {
-					var dest = (fileConfig.orig.expand) ? fileConfig.dest : path.join(fileConfig.dest, fileConfig.src);
+					var dest;
+					if (fileConfig.relativeTo) {
+						dest = (fileConfig.orig.expand) ? fileConfig.dest : path.join(fileConfig.dest, fileConfig.src.replace(fileConfig.relativeTo, ''));
+					}
+					else {
+						dest = (fileConfig.orig.expand) ? fileConfig.dest : path.join(fileConfig.dest, fileConfig.src);
+					}
 					filepathDest = path.join(buildPath, dest);
 				} else {
 					filepathDest = path.join(buildPath, fileConfig.dest);


### PR DESCRIPTION
This fix is intended to allow removing some part of the final files path when packaging the RPM. It could help for issue https://github.com/gastonelhordoy/grunt-rpm/issues/17