### PR TITLE
Adding support for custom directives

### DIFF
--- a/tasks/lib/default-spec-writer.js
+++ b/tasks/lib/default-spec-writer.js
@@ -82,6 +82,16 @@ function formatFileList(options) {
 				str += '%config ' + config + '\n';
 			}
 		}
+
+		if (options.directives) {
+			for (var l in options.directives) {
+				var d = options.directives[l];
+				var directive = d.directive;
+				var file = d.file;
+				str += directive + ' ' + file + '\n';
+			}
+		}
+
 		for (var i in options.files) {
 			var rpmFile = options.files[i];
 //			if (!rpmFile.noRecursion) {


### PR DESCRIPTION
I was recently trying to add a %config(noreplace) directive. Rather than implementing this specific directive (or extra options for %config), it seemed like a useful feature to be able to add any custom directive, such as:

    directives: [{
        directive: '%config(noreplace)',
        file: '/my/config/file'
    }]